### PR TITLE
service/status = 0 actually means running

### DIFF
--- a/monit.py
+++ b/monit.py
@@ -63,7 +63,7 @@ class Monit(dict):
             self.daemon = daemon
             self.running = None
             if self.type != 'system':
-                self.running = bool(int(xml.find('status').text))
+                self.running = not bool(int(xml.find('status').text))
             self.monitored = bool(int(xml.find('monitor').text))
         
         def start(self):


### PR DESCRIPTION
Per monit/src/event.h when there's no event (Event_Null = 0x0) the service is supposed to be running, so status should probably be flipped.
