### PR TITLE
 fixed authenticated requests to work with csrf prevention

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 setup(
     name='monit',
     description='Interface to the Monit system manager and monitor (http://mmonit.com/monit/)',
-    version='0.3',
+    version='0.4',
     author='Camilo Polymeris',
     author_email='cpolymeris@gmail.com',
     url='https://github.com/polymeris/python-monit',


### PR DESCRIPTION
* fixed authenticated requests to work with csrf prevention
* added error checking on request responses
* bumped version in setup.py to 0.4

Please consider for merging and pushing to pip. monit.py doesn't work with monit (version 5.20.0) for me without this. I also added error checking on request responses so you get meaningful exceptions if the communication with the monit server fails.